### PR TITLE
Fix typos in the introductory tutorials

### DIFF
--- a/Mojo/Creating a Project
+++ b/Mojo/Creating a Project
@@ -73,21 +73,21 @@ You may have noticed this line.
     output[7:0]led,
 This is not a single output but actually 8! You can create an array of wires (or regs)  by using those brackets. What [7:0] actually means is that led will be an array of eight wires that have an index from 7 down to 0, inclusive. 
 
-It is possible to do [8:1] or [0:7], but unless you have a very very good reason for doing that then you should stick to the convention. Mixing what you used as a base index and the order can create major head-aches.
+It is possible to do [8:1] or [0:7], but unless you have a very very good reason for doing that then you should stick to the convention. Mixing what you used as a base index and the order can create major headaches.
 
 Declaring a wire
 
 This brings us to the first line after the port declaration. 
 
 wire rst = ~rst_n;
-This line we are declaring a new wire called rst and assigning it a value.
+In this line we are declaring a new wire called rst and assigning it a value.
 
 It is a common convention to name signals that are active low (meaning a 0 is active) by appending _n to the end of their name. Following that convention, rst_n is active low, but we want an active high signal. To make rst an active high version of rst_n we can just invert rst_n. The ~ operator is the not operator. 
 
 In this case, we are declaring a one bit wire. However, you can declare an array of wires (sometimes also called an n-bit wire where n is the width of the array) with the following line.
 
 wire [9:0] array;
-In this case, we now have a 10-bit wire called array. Notice here I did not assign it a value.
+In this case, we would now have a 10-bit wire called array. Notice here I did not assign it a value.
 
 Assigning a value
 
@@ -106,7 +106,7 @@ Now you may be looking at the assign statements and thinking "what the *&$(* kin
 
 In this case, since we are not using the spi signals we disconnect them because driving them incorrectly could damage the microcontroller. 
 
-Now, lets look at the last line. This is the one we care about. Right now we are just assigning led to be all 0s. That means all the LEDs will always be off! What fun is that? Let's make a small modification to that line.
+Now, let's look at the last line. This is the one we care about. Right now we are just assigning led to be all 0s. That means all the LEDs will always be off! What fun is that? Let's make a small modification to that line.
 
 assign led[6:0] = 7'b0;
 assign led[7] = rst;
@@ -140,4 +140,4 @@ If it doesn't work, make sure you have the correct port selected and the board i
 
 Once it has transferred, try pressing the reset button. When you push the button the LED closest to the button should light up.
 
-Congratulations you've completed your first project!
+Congratulations, you've completed your first project!

--- a/Mojo/Installing ISE
+++ b/Mojo/Installing ISE
@@ -1,20 +1,20 @@
-ISE is a program created by Xilinx to support their FPGAs. It includes a bunch of other tools that will be useful for creating your projects. ISE is required to do any work becuase it is what actually synthesizes your designs into bit files that can be loaded onto the Mojo.
+ISE is a program created by Xilinx to support their FPGAs. It includes a bunch of other tools that will be useful for creating your projects. ISE is required to do any work because it is what actually synthesizes your designs into bit files that can be loaded onto the Mojo.
 
 The process is fairly long, but it shouldn't be too tricky if you follow these instructions. These instructions were written for ISE 14.5 and tested on Ubuntu 12.04, Ubuntu 12.10, Linux Mint, Windows 7, and Windows 8.
 
-First click here to go to the Xilinx downloads page. Under version select the newest (14.5 at the time of writing). Scroll down a bit until you see ISE Design Suite. Under that header you should see full installers for windows and linux. Choose the one for the system you are installing ISE on.
+First click here to go to the Xilinx downloads page. Under "Version" select the newest (14.5 at the time of writing). Scroll down a bit until you see ISE Design Suite. Under that header you should see full installers for Windows and Linux. Choose the one for the system you are installing ISE on.
 
 You will then be prompted to login. If you don't have an account, create one. Once you have logged in the download should start.
 
 If you have Java installed, you may be prompted to use their "Download Manager", if not it will just start like any other download. The method you use does not make a difference; however, if you have problems with the download manager you can disable Java in your browser and try again to prevent it from using it.
 
-The file is big, about 6.5GB, so make sure you have plenty of space!
+The file is big, about 6.5GB, so make sure you have plenty of space! (Also, the installation requires a further 16GB of space.)
 
 Once the file is downloaded you need to decompress it. The file is a tar file so if you are on Windows you will need to install something like WinZip.
 
 For Windows, just open the folder and double click on xsetup to start the installation.
 
-For Linux, you will need to open up a terminal and cd into the directory you extracted the files. Then run the setup with sudo ./xsetup.
+For Linux, you will need to open up a terminal and cd into the directory where you extracted the files. Then run the setup with sudo ./xsetup.
 
 Once in the setup, accept all the license agreements. Once you are on the page that asks which edition to install, choose the ISE WebPACK option and click next.
 
@@ -42,7 +42,7 @@ If you are a Windows user you can stop here. However, if you are using Linux the
 
 Windows 8 64bit
 
-To get your license installed in Windows 8 you need to create a folder in the root of your home drive (usually C). Name the folder .xilinx. note both dots. Once you made the folder it should show up as .xilinx (no trailing dot). For whatever reason, Windows requires you to have that trailing dot and it removes it automatically. Once you have that folder created just drop your Xilinx.lic file into it. ISE should now find the license file and open without complaints.
+To get your license installed in Windows 8 you need to create a folder in the root of your home drive (usually C). Name the folder ".xilinx." Note both dots. Once you made the folder it should show up as .xilinx (no trailing dot). For whatever reason, Windows requires you to have that trailing dot and it removes it automatically. Once you have that folder created just drop your Xilinx.lic file into it. ISE should now find the license file and open without complaints.
 
 The 64bit version of ISE doesn't work correctly in Windows 8. Every time it tries to open a file dialog it crashes. To fix this you need to use the 32bit version.
 
@@ -58,7 +58,7 @@ If you would like a shortcut on your start screen, rename the file you just past
 
 Pin ISE to Windows 8 Start
 
-Once it is pinned you need to rename it back to ise. I found that trick of renaming, pinning, change name back to be useful to make the laucher on the start page.
+Once it is pinned you need to rename it back to ise. I found that trick of renaming, pinning, change name back to be useful to make the launcher on the start page.
 
 Creating a launcher in Linux
 

--- a/Mojo/Installing Mojo Loader
+++ b/Mojo/Installing Mojo Loader
@@ -18,11 +18,11 @@ sudo apt-get install openjdk-7-jre-headless
 You will also need to be a member of the dialout group to be able to use the serial port. You can add yourself by entering this line.
 
 sudo usermod -a -G dialout `whoami`
-You will have to logout or restart your computer for that to take effect.
+You will have to log out or restart your computer for that to take effect.
 
 Windows
 
-The V2 of the Mojo features a USB port which uses Window's built in driver for USB->Serial devices. However, by default Windows will not recognize the Mojo. You will need to point it to the driver.
+The V2 of the Mojo features a USB port which uses Windows's built in driver for USB->Serial devices. However, by default Windows will not recognize the Mojo. You will need to point it to the driver.
 
 If you are using Windows 8 you will need to disable driver signature enforcement. You can find instructions on how to do this here.
 
@@ -34,7 +34,7 @@ Device Manager
 
 Right click on Mojo V2 and select Properties. On the top of the new window you should have three tabs. Click the Driver tab.
 
-Under the Driver tab you should have a button labled Update Driver... click that.
+Under the Driver tab you should have a button labeled Update Driver... click that.
 
 In the new windows choose Browse my computer for driver software.
 

--- a/Mojo/Updating the Mojo
+++ b/Mojo/Updating the Mojo
@@ -11,11 +11,11 @@ It is pretty easy to update the Mojo in Ubuntu using dfu-programmer.
 First you need to install dfu-programmer. Open a terminal and enter
 
 sudo apt-get install dfu-programmer
-You also need to download the following file and place it in /etc/udev/rules.d. You will need super user rights to do this.
+You also need to download the following file and place it in /etc/udev/rules.d. You will need superuser privileges to do this.
 
 Mojo USB Rules
 
-Once you add the rules file, you will need to unplug and re-plug the Mojo to have it take affect. 
+Once you add the rules file, you will need to unplug and re-plug the Mojo to have it take effect. 
 
 Jump down to Entering Bootloader Mode for instructions on how to get the Mojo into bootloader mode.
 
@@ -38,7 +38,7 @@ There are two flavors of FLIP, one with a Java Runtime included and one without.
 
 Once you've installed FLIP, jump down to Entering Bootloader Mode for instructions on how to get the Mojo into bootloader mode.
 
-Windows may or may not find the driver for you Mojo. If it doesn't, open the Device Manager. It should look similar to below.
+Windows may or may not find the driver for your Mojo. If it doesn't, open the Device Manager. It should look similar to below.
 
 Device Manager
 

--- a/Mojo/What is an FPGA?
+++ b/Mojo/What is an FPGA?
@@ -2,13 +2,13 @@ So what exactly is an FPGA? You may have heard the term thrown around, or maybe 
 
 You can think of an FPGA as a blank slate. By itself an FPGA does nothing. It is up to you (the designer) to create a configuration file, often called a bit file, for the FPGA. Once loaded the FPGA will behave like the digital circuit you designed!
 
-One of the reasons FPGAs are so awesome is that unlike an ASIC (Application Specific Integrated Circuit) the circuit design is not set and you can reconfigure an FPGA as many times as you like! Creating an ASIC also costs potentially millions of dollars and takes weeks or months to create. That's not exactly hobbiest friendly.
+One of the reasons FPGAs are so awesome is that unlike an ASIC (Application Specific Integrated Circuit) the circuit design is not set and you can reconfigure an FPGA as many times as you like! Creating an ASIC also costs potentially millions of dollars and takes weeks or months to create. That's not exactly hobbyist friendly.
 
 FPGA vs Microcontroller
 
-When I first learned about FPGAs, all I really knew about before was microcontrollers. So first it is important to understand that they are very different devices. With a microcontoller, like an Arduino, the chip is already designed for you. You simply write some software, usually in C or C++, and compile it to a hex file that you load onto the microcontroller. The microcontroller stores the program in flash memory and will store it until it is erased or replaced. With microcontrollers you have control over the software.
+When I first learned about FPGAs, all I really knew about before was microcontrollers. So first it is important to understand that they are very different devices. With a microcontroller, like an Arduino, the chip is already designed for you. You simply write some software, usually in C or C++, and compile it to a hex file that you load onto the microcontroller. The microcontroller stores the program in flash memory and will store it until it is erased or replaced. With microcontrollers you have control over the software.
 
-FPGAs are different. You are the one designing the circuit. There is no processor to run software on, at least until you design one! You can configure an FPGA to be something as simple as an and gate, or something as complex as a multi-core processor. To create your design, you write some HDL (Hardware Description Language). The two most popular HDLs are Verilog and VHDL. You then synthesize your HDL into a bit file which you can use to configure the FPGA. A slight downside to FPGAs is that they store their configuration in RAM, not flash, meaning that once they lose power they lose their configuration. They must be configured everytime time power is applied.
+FPGAs are different. You are the one designing the circuit. There is no processor to run software on, at least until you design one! You can configure an FPGA to be something as simple as an AND gate, or something as complex as a multi-core processor. To create your design, you write some HDL (Hardware Description Language). The two most popular HDLs are Verilog and VHDL. You then synthesize your HDL into a bit file which you can use to configure the FPGA. A slight downside to FPGAs is that they store their configuration in RAM, not flash, meaning that once they lose power they lose their configuration. They must be configured every time power is applied.
 
 That is not as bad as it seems as there are flash chips you can use that will automatically configure the stored bit file on power up. There are also some development boards which don't require a programmer at all and will configure the FPGA at startup.
 
@@ -18,8 +18,8 @@ The Possibilities
 
 With a typical microprocessor, you have dedicated pins for specific features. For example there will be only two pins on some microprocessors that are used as a serial port. If you want more than one serial port, or you want to use some other pins, your only solution besides getting a different chip is to use software to emulate a serial port. That works fine except you are wasting valuable processor time with the very basic task of sending out bits. If you want to emulate more than one port then you end up using all your processor time.
 
-With an FPGA you are able to create the actual circuit, so it is up to you to decide what pins the serial port connects to. That also means you can create as many serial ports as you want. The only limitations you really have are the number of physical IO pins and the size of the FPGA.
+With an FPGA you are able to create the actual circuit, so it is up to you to decide what pins the serial port connects to. That also means you can create as many serial ports as you want. The only limitations you really have are the number of physical I/O pins and the size of the FPGA.
 
-Just like microcontrollers that have a set amount of memory for your program, FPGAs can only emulate a cicuit so large.
+Just like microcontrollers that have a set amount of memory for your program, FPGAs can only emulate a circuit so large.
 
 One of the very interesting things about FPGAs is that while you are designing the hardware, you can design the hardware to be a processor that you then can write software for! In fact, companies that design digital circuits, like Intel or nVidia, often use FPGAs to prototype their chips before creating them.


### PR DESCRIPTION
Corrections for the typos and minor issues I noticed when reading through the introductory tutorials. I tried to avoid getting into nitpick territory regarding commas and the like, so these should all be clear and evident fixes.

I also added a note regarding the total disk space required for ISE WebPack installation, as that was actually something that I had a problem with; namely, I had to resize my Linux virtual machine's disks to be able to install ISE after it informed me it wanted 16GB space. Good to have a warning about that up front.

Note also issue #1, which precluded typo corrections to the "How does an FPGA work?" page (it does have typos).
